### PR TITLE
FIX: Move validation after setting BIDS configuration

### DIFF
--- a/niviz_rater/index.py
+++ b/niviz_rater/index.py
@@ -130,7 +130,7 @@ def build_index(qc_dataset, qc_config, bids_config=None):
                         index_metadata=False,
                         config=["user"])
 
-    bidsfiles = layout.get(extension=qc_config['ImageExtensions'])
+    bidsfiles = layout.get(extension=config['ImageExtensions'])
 
     row_tpl = AxisNameTpl(Template(config['RowDescription']['name']),
                           config['RowDescription']['entities'])

--- a/niviz_rater/index.py
+++ b/niviz_rater/index.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 from bids.layout import BIDSLayout, add_config_paths
 import bids.config
 
-from niviz.validation import validate_config
+from niviz_rater.validation import validate_config
 from niviz_rater import db
 from niviz_rater.models import (Entity, Rating, Image, Component, TableRow,
                                 TableColumn)

--- a/niviz_rater/index.py
+++ b/niviz_rater/index.py
@@ -120,7 +120,6 @@ def build_index(qc_dataset, qc_config, bids_config=None):
 
     if bids_config is None:
         bids_config = DEFAULT_BIDS
-        print(DEFAULT_BIDS)
 
     add_config_paths(user=bids_config)
     bids_configs = bids.config.get_option('config_paths').values()

--- a/niviz_rater/index.py
+++ b/niviz_rater/index.py
@@ -3,7 +3,6 @@ Module for handling and enforcing configuration rules for
 packaging and rules for associating QC images with an entity
 '''
 
-import yaml
 import os
 from itertools import groupby
 import logging
@@ -12,9 +11,12 @@ from dataclasses import dataclass
 from collections import namedtuple
 
 from bids.layout import BIDSLayout, add_config_paths
+import bids.config
+
 from niviz.validation import validate_config
 from niviz_rater import db
-from niviz_rater.models import Entity, Rating, Image, Component, TableRow, TableColumn
+from niviz_rater.models import (Entity, Rating, Image, Component, TableRow,
+                                TableColumn)
 
 logger = logging.getLogger(__name__)
 
@@ -111,20 +113,6 @@ class ConfigComponent:
         return qc_entities
 
 
-def get_qc_bidsfiles(qc_dataset, qc_config, bids_config):
-    '''
-    Get BIDSFiles associated with qc_dataset
-    '''
-
-    add_config_paths(user=bids_config)
-    layout = BIDSLayout(qc_dataset,
-                        validate=False,
-                        index_metadata=False,
-                        config=["user"])
-    bidsfiles = layout.get(extension=qc_config['ImageExtensions'])
-    return bidsfiles
-
-
 def build_index(qc_dataset, qc_config, bids_config=None):
     '''
     Build database
@@ -134,8 +122,17 @@ def build_index(qc_dataset, qc_config, bids_config=None):
         bids_config = DEFAULT_BIDS
         print(DEFAULT_BIDS)
 
-    config = _validate_config(qc_config)
-    bidsfiles = get_qc_bidsfiles(qc_dataset, config, bids_config)
+    add_config_paths(user=bids_config)
+    bids_configs = bids.config.get_option('config_paths').values()
+
+    config = validate_config(qc_config, bids_configs)
+    layout = BIDSLayout(qc_dataset,
+                        validate=False,
+                        index_metadata=False,
+                        config=["user"])
+
+    bidsfiles = layout.get(extension=qc_config['ImageExtensions'])
+
     row_tpl = AxisNameTpl(Template(config['RowDescription']['name']),
                           config['RowDescription']['entities'])
 

--- a/niviz_rater/utils.py
+++ b/niviz_rater/utils.py
@@ -1,0 +1,7 @@
+import json
+
+
+def _load_json(file):
+    with open(file, 'r') as f:
+        result = json.load(f)
+    return result

--- a/niviz_rater/utils.py
+++ b/niviz_rater/utils.py
@@ -1,7 +1,7 @@
 import json
 
 
-def _load_json(file):
+def load_json(file):
     with open(file, 'r') as f:
         result = json.load(f)
     return result

--- a/niviz_rater/validation.py
+++ b/niviz_rater/validation.py
@@ -3,24 +3,20 @@ import json
 import os
 import yamale
 from yamale.validators import DefaultValidators, Validator
-from bids.config import get_option
 
 SCHEMAFILE = os.path.join(os.path.dirname(__file__), 'data/schema.yaml')
 
 
-def load_json(file):
+def _load_json(file):
     with open(file, 'r') as f:
         result = json.load(f)
     return result
 
 
-def get_entities():
-    configfiles = [
-        load_json(file)['entities']
-        for file in get_option('config_paths').values()
-    ]
+def _get_valid_entities(config_files):
+    valid_configs = [_load_json(file)['entities'] for file in config_files]
     enumstrs = []
-    for configfile in configfiles:
+    for configfile in valid_configs:
         enumstrs.extend([entity['name'] for entity in configfile])
     return enumstrs
 
@@ -28,20 +24,44 @@ def get_entities():
 class Entities(Validator):
     '''
     Class to enable validation of BIDS entities
+    from pyBIDS JSON configuration files
     '''
+
+    __slots__ = "valid_configs"
 
     tag = 'Entities'
 
+    def __init__(self, valid_configs):
+        self.valid_configs = valid_configs
+        super(Entities, self).__init__()
+
     def _is_valid(self, value):
-        return value in get_entities()
+        return value in _get_valid_entities(self.valid_configs)
 
 
-def validate_config(config):
+def validate_config(config, bids_configs, schema_file=SCHEMAFILE):
+    '''
+    Validate a YAML-based configuration file against a
+    schema file containing BIDS entity constraints
+
+    Args:
+        config (str): Path to YAML configuration file to be validated
+        bids_configs (:obj: `list` of :obj: `str): List of paths to pyBIDS
+            configuration files to include in validation
+        schema_file (str): Path to YAML schema to validate against. Defaults
+            to niviz_rater/data/schema.yaml
+
+    Returns:
+        config (dict): Parsed configuration file
+
+    Raises:
+        YamaleError: If validation fails due to invalid `config` file
+    '''
 
     validators = DefaultValidators.copy()
-    validators[Entities.tag] = Entities
+    validators[Entities.tag] = Entities(valid_configs=bids_configs)
 
-    schema = yamale.make_schema(SCHEMAFILE, validators=validators)
+    schema = yamale.make_schema(schema_file, validators=validators)
     yamaledata = yamale.make_data(config)
     yamale.validate(schema, yamaledata)
 

--- a/niviz_rater/validation.py
+++ b/niviz_rater/validation.py
@@ -1,20 +1,16 @@
 import os
 import yaml
-import json
 import yamale
 from yamale.validators import DefaultValidators, Validator
+import niviz_rater.utils as utils
 
 SCHEMAFILE = os.path.join(os.path.dirname(__file__), 'data/schema.yaml')
 
 
-def _load_json(file):
-    with open(file, 'r') as f:
-        result = json.load(f)
-    return result
-
-
-def _get_valid_entities(config_files):
-    valid_configs = [_load_json(file)['entities'] for file in config_files]
+def _get_valid_entities(bids_config_files):
+    valid_configs = [
+        utils.load_json(file)['entities'] for file in bids_config_files
+    ]
     enumstrs = []
     for configfile in valid_configs:
         enumstrs.extend([entity['name'] for entity in configfile])
@@ -25,11 +21,31 @@ class Entities(Validator):
     '''
     Class to enable validation of BIDS entities
     from pyBIDS JSON configuration files
+
+    Note:
+        This class cannot be used in isolation. Instead
+        create a copy of the class with the `valid_configs`
+        property set
     '''
 
     __slots__ = "valid_configs"
 
     tag = 'Entities'
+
+    def __init__(self, *args, **kwargs):
+        '''
+        Perform a check to ensure that `valid_configs` is
+        defined
+
+        Raises:
+            AttributeError: If `valid_configs` is not defined
+        '''
+
+        if self.valid_configs is None:
+            raise AttributeError('`valid_configs` property of Entities '
+                                 'class is not set. Create copy of class '
+                                 'and set `valid_configs`!')
+        super(Entities, self).__init__(*args, **kwargs)
 
     def _is_valid(self, value):
         return value in _get_valid_entities(self.valid_configs)

--- a/niviz_rater/validation.py
+++ b/niviz_rater/validation.py
@@ -27,7 +27,7 @@ class Entities(Validator):
     from pyBIDS JSON configuration files
     '''
 
-    __slots__ = "valid_configs"
+    __slots__ = 'valid_configs'
 
     tag = 'Entities'
 

--- a/niviz_rater/validation.py
+++ b/niviz_rater/validation.py
@@ -44,9 +44,9 @@ def _configure_entity_validator(bids_configs):
     to validate against
     '''
 
-    PatchedEntities = Entities
-    PatchedEntities.valid_configs = bids_configs
-    return PatchedEntities
+    ConfiguredEntities = Entities
+    ConfiguredEntities.valid_configs = bids_configs
+    return ConfiguredEntities
 
 
 def validate_config(config, bids_configs, schema_file=SCHEMAFILE):
@@ -68,9 +68,9 @@ def validate_config(config, bids_configs, schema_file=SCHEMAFILE):
         YamaleError: If validation fails due to invalid `config` file
     '''
 
-    PatchedEntities = _configure_entity_validator(bids_configs)
+    ConfiguredEntities = _configure_entity_validator(bids_configs)
     validators = DefaultValidators.copy()
-    validators[Entities.tag] = PatchedEntities
+    validators[ConfiguredEntities.tag] = ConfiguredEntities
 
     schema = yamale.make_schema(schema_file, validators=validators)
     yamaledata = yamale.make_data(config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
 	bottle
 	peewee
 	PyYAML
+	yamale
 packages = find:
 zip_safe = true
 


### PR DESCRIPTION
Major changes are that I moved pulling the list of BIDS configuration files out of validation (separation of concerns). 

This ended up causing problems with how the Entities object can access the list of bids configuration files to use. To this end, I implemented a little hack to dynamically create a new class `PatchedEntity` that is a modified `Entity` class where the list of BIDS configuration files are set as a class variable.

If you know a better way to handle this, would be happy to hear!