### PR TITLE
ENH: add CLI entry point

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,7 @@ all =
 buildtest =
 	%(lint)s
 	%(test)s
+
+[options.entry_points]
+console_scripts =
+  niviz-rater = niviz_rater.app:main


### PR DESCRIPTION
Update `setup.cfg` to add a `niviz-rater` entry-point exposing the application's CLI