### PR TITLE
FIX: set extract to false to resolve issue with CSS being undefined

### DIFF
--- a/niviz_rater/client/rollup.config.js
+++ b/niviz_rater/client/rollup.config.js
@@ -5,7 +5,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 import css from 'rollup-plugin-css-only';
-import autoPreprocess from 'svelte-preprocess';
+import sveltePreprocess from 'svelte-preprocess';
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -40,18 +40,20 @@ export default {
 	},
 	plugins: [
 		svelte({
-			compilerOptions: {
-				// enable run-time checks when not in production
-				dev: !production
-			},
-			css: css => {
-				css.write('public/build/bundle.css')
-			},
-			preprocess: autoPreprocess(),
-			emitCss: true,
+      preprocess: sveltePreprocess(),
+      emitCss: false,
+      compilerOptions: {
+        // enable run-time checks when not in production
+        dev: !production,
+
+        css: css => {
+          css.write('public/build/bundle.css')
+        }
+      }
+
 		}),
 		postcss({
-			extract: true,
+			extract: false,
 			minimize: true,
 			use: [
 				[


### PR DESCRIPTION
Solution found here:
https://github.com/hperrin/svelte-material-ui/issues/162

Other changes ensure that dev/css options aren't ignored