### PR TITLE
FIX: Real fix for CSS not being unpacked correctly

### DIFF
--- a/niviz_rater/client/rollup.config.js
+++ b/niviz_rater/client/rollup.config.js
@@ -54,7 +54,7 @@ export default {
 		}),
 		postcss({
 			extract: true,
-			minimize: false,
+			minimize: true,
 			use: [
 				[
 					"sass",

--- a/niviz_rater/client/rollup.config.js
+++ b/niviz_rater/client/rollup.config.js
@@ -53,8 +53,8 @@ export default {
 
 		}),
 		postcss({
-			extract: false,
-			minimize: true,
+			extract: true,
+			minimize: false,
 			use: [
 				[
 					"sass",
@@ -69,7 +69,7 @@ export default {
 		}),
 		// we'll extract any component CSS out into
 		// a separate file - better for performance
-		css({ output: 'bundle.css' }),
+		css({ output: 'extras.css' }),
 
 		// If you have external dependencies installed from
 		// npm, you'll most likely need these plugins. In


### PR DESCRIPTION
37507683f77c494d01c5ce453c6ac7bb765cc02a did not actually resolve the issue. Turning off extract resulted in the bundle.css file not being correctly unpacked as a CSS file. The solution is to separate out the postCss CSS output into an extras.css. My guess is that there is some I/O writing over the same bundle.css file that was causing the issue..