### PR TITLE
ENH: Use DatabaseProxy to allow for runtime configuration of app DB

### DIFF
--- a/niviz_rater/db.py
+++ b/niviz_rater/db.py
@@ -1,22 +1,28 @@
 from peewee import SqliteDatabase
-from typing import Any, List, Optional
-
-# As much as it would be nice to have this be passed into the app via a
-# configuration file, but peewee Models are not compatible with this
-# To use an in-memory db, use 'file::memory:?cache=shared'
-DB_NAME: str = 'test.db'
-
-sqlite_db: Optional[SqliteDatabase] = None
+from typing import Any, List, Optional, Callable
 
 
-def get_or_create_db(additional_pragmas: Optional[List[Any]] = None
-                     ) -> SqliteDatabase:
-    global sqlite_db
-    if sqlite_db:
-        return sqlite_db
+def get_or_create_db(
+        db_str: str,
+        additional_pragmas: Optional[List[Any]] = None) -> SqliteDatabase:
+
     pragmas = [('foreign_keys', 'on')]
     if additional_pragmas:
         pragmas.append(additional_pragmas)
-    sqlite_db = SqliteDatabase(DB_NAME, pragmas=pragmas, uri=True)
+
+    sqlite_db = SqliteDatabase(db_str, pragmas=pragmas, uri=True)
     return sqlite_db
 
+
+def fetch_db_from_config(app_config,
+                         additional_pragmas: Optional[List[Any]] = None):
+    """
+    Fetch database by first trying to pull from
+    stored application configuration and if fail, then
+    resort to requesting one using db_file
+    """
+
+    return app_config.get(
+        'niviz_rater.db.instance',
+        get_or_create_db(app_config['niviz_rater.db.file'],
+                         additional_pragmas))

--- a/niviz_rater/models.py
+++ b/niviz_rater/models.py
@@ -1,10 +1,11 @@
-from peewee import (Model, ForeignKeyField, TextField, CharField, BooleanField)
-from niviz_rater.db import get_or_create_db
+from peewee import (Model, ForeignKeyField, TextField, CharField, BooleanField, DatabaseProxy)
+
+database_proxy = DatabaseProxy()
 
 
 class BaseModel(Model):
     class Meta:
-        database = get_or_create_db()
+        database = database_proxy
 
 
 class Component(BaseModel):
@@ -42,7 +43,7 @@ class Entity(Model):
     rating = ForeignKeyField(Rating, null=True, backref='+')
 
     class Meta:
-        database = get_or_create_db()
+        database = database_proxy
         indexes = ((("name", ), True), )
 
     @property


### PR DESCRIPTION
This PR enables the application to have a user-configurable database string when initializing and/or running the application.


A possible next step would be to read DB information from either environment variables or a passed in JSON/YAML file. This way niviz can be integrated with hosted DBs (i.e PostgresSQL)