### PR TITLE
FIX: Set "No Rating" as a selectable option

### DIFF
--- a/niviz_rater/client/src/ItemRatingView.svelte
+++ b/niviz_rater/client/src/ItemRatingView.svelte
@@ -31,6 +31,7 @@
 	}
 
 	let availableRatings = item.availableRatings.map(r => r.id);
+
 	export function setRating(num){
 		if (availableRatings.includes(num)){
 			rating_id=num;
@@ -64,7 +65,6 @@
 			<div class="tile is-child">
 				<div class="select">
 					<select bind:value={rating_id}>
-						<option value="" selected disabled hidden>Select rating</option>
 						{#each item.availableRatings as rating (rating)}
 							<option value={rating.id}>{rating.name}</option>
 						{/each}
@@ -77,7 +77,7 @@
 						<label class="radio">
 							<input type="radio"
 								  use:markRadioDefault={checked}
-								  name="passfail" 
+								  name="passfail"
 								 {value} bind:group={qc_rating}>
 							{name}
 						</label>

--- a/niviz_rater/index.py
+++ b/niviz_rater/index.py
@@ -44,6 +44,7 @@ class ConfigComponent:
     Configurable Factory class for building QC components
     from list of images
     """
+
     def __init__(self, entities, name, column, images, ratings):
         self.entities = entities
         self.name = name
@@ -114,8 +115,7 @@ class ConfigComponent:
         return qc_entities
 
 
-def build_index(db: SqliteDatabase,
-                bids_files: Iterable[str],
+def build_index(db: SqliteDatabase, bids_files: Iterable[str],
                 qc_spec: Dict[str, Any]) -> None:
     """
     Initialize database with objects
@@ -125,10 +125,8 @@ def build_index(db: SqliteDatabase,
 
     for c in qc_spec['Components']:
         component = ConfigComponent(**c)
-        make_database(db,
-                      component.build_qc_entities(bids_files),
-                      component.available_ratings,
-                      row_tpl)
+        make_database(db, component.build_qc_entities(bids_files),
+                      component.available_ratings, row_tpl)
 
 
 def make_rowname(rowtpl, entities):
@@ -146,7 +144,8 @@ def make_database(db, entities, available_ratings, row_tpl):
     # Step 0: We'll create our component and ratings
     with db.atomic():
         component = Component.create()
-        default_rating = Rating.create(name="No Rating", component=component.id)
+        default_rating = Rating.create(name="No Rating",
+                                       component=component.id)
         [
             Rating.create(name=r, component=component.id)
             for r in available_ratings

--- a/niviz_rater/index.py
+++ b/niviz_rater/index.py
@@ -146,6 +146,7 @@ def make_database(db, entities, available_ratings, row_tpl):
     # Step 0: We'll create our component and ratings
     with db.atomic():
         component = Component.create()
+        default_rating = Rating.create(name="No Rating", component=component.id)
         [
             Rating.create(name=r, component=component.id)
             for r in available_ratings
@@ -167,7 +168,8 @@ def make_database(db, entities, available_ratings, row_tpl):
             entity = Entity.create(name=e.name,
                                    component=component.id,
                                    rowname=make_rowname(row_tpl, e.entities),
-                                   columnname=e.column_name)
+                                   columnname=e.column_name,
+                                   rating=default_rating.id)
             [image_inserts.append((i, entity.id)) for i in e.images]
 
     with db.atomic():

--- a/niviz_rater/models.py
+++ b/niviz_rater/models.py
@@ -40,7 +40,7 @@ class Entity(Model):
     component = ForeignKeyField(Component, null=False, backref='+')
     comment = TextField(default="")
     failed = BooleanField(null=True)
-    rating = ForeignKeyField(Rating, null=True, backref='+')
+    rating = ForeignKeyField(Rating, null=False, backref='+')
 
     class Meta:
         database = database_proxy


### PR DESCRIPTION
This fix initializes all entities will a selectable "No Rating" option to indicate that the entity has no associated categories (i.e if it passes or un-doing an accidental selection).

This is implemented in the back-end, and so removes some logic handling on the client's part which is the preferable solution (vs. having the client handle no rating logic explicitly)