### PR TITLE
FIX: Remove deprecated RowEntities key

### DIFF
--- a/niviz_rater/data/schema.yaml
+++ b/niviz_rater/data/schema.yaml
@@ -1,5 +1,4 @@
 ImageExtensions: list(str(ignore_case = True), min = 1)
-RowEntities: list(str(), min=1)
 
 RowDescription:
   entities: list(include('entity'), min = 1)


### PR DESCRIPTION
entities required for Rows are specified under `RowDescription`