### PR TITLE
FIX: Escape newlines in comment

### DIFF
--- a/niviz_rater/models.py
+++ b/niviz_rater/models.py
@@ -71,7 +71,7 @@ class Entity(Model):
         else:
             rating = self.rating.name
 
-        return (annotation, rating, self.comment or "")
+        return (annotation, rating, self.comment.replace("\n","\\n") or "")
 
 
 class Image(BaseModel):

--- a/niviz_rater/models.py
+++ b/niviz_rater/models.py
@@ -31,10 +31,6 @@ class Rating(BaseModel):
     name = CharField()
 
 
-class Rating(BaseModel):
-    name = CharField()
-
-
 class TableColumn(BaseModel):
     name = CharField(primary_key=True)
 
@@ -71,7 +67,7 @@ class Entity(Model):
         else:
             rating = self.rating.name
 
-        return (annotation, rating, self.comment.replace("\n","\\n") or "")
+        return (annotation, rating, self.comment.replace("\n", "\\n") or "")
 
 
 class Image(BaseModel):


### PR DESCRIPTION
Newlines in comments currently cause exported TSVs to split up records into multiple rows